### PR TITLE
Fix empty `instance_config.yml` produced by `header` filter

### DIFF
--- a/changelogs/fragments/1-mas-fix-no-app-installed.yml
+++ b/changelogs/fragments/1-mas-fix-no-app-installed.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - "fix empty `instance_config.yml`` produced by ``header`` filter (https://github.com/ansible-collections/community.molecule/pull/1)."
+  - "fix empty ``instance_config.yml`` produced by ``header`` filter (https://github.com/ansible-collections/community.molecule/pull/1)."

--- a/changelogs/fragments/1-mas-fix-no-app-installed.yml
+++ b/changelogs/fragments/1-mas-fix-no-app-installed.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "fix empty `instance_config.yml`` produced by ``header`` filter (https://github.com/ansible-collections/community.molecule/pull/1)."

--- a/playbooks/validate.yml
+++ b/playbooks/validate.yml
@@ -8,6 +8,15 @@
       debug:
         msg: "{{ '' | community.molecule.header }}"
 
+    - name: Test community.molecule.header filter result
+      set_fact:
+        with_header: "{{ '# This is test content\n' | community.molecule.header }}"
+
+    - name: Assert community.molecule.header filter result
+      assert:
+        that:
+          - "'# Molecule managed\n\n# This is test content\n' == with_header"
+
     - name: Check if community.molecule.to_yaml filter can be used
       debug:
         msg: "{{ '' | community.molecule.to_yaml }}"

--- a/plugins/filter/molecule_core.py
+++ b/plugins/filter/molecule_core.py
@@ -37,8 +37,8 @@ def to_yaml(data):
 
 
 def header(content):
-    """Return heaader to be added."""
-    return "# Molecule managed\n\n"
+    """Prepend molecule header."""
+    return util.molecule_prepender(content)
 
 
 def get_docker_networks(data, state, labels=None):


### PR DESCRIPTION
Filter 'header' was previously 'molecule_header'. This filter should
prepend molecule header to the input content. But it was buggy since
probably move to community.molecule.

##### ISSUE TYPE
- Bugfix Pull Request
